### PR TITLE
Fixed some problems with the screen off timer

### DIFF
--- a/src/de/j4velin/wifiAutoOff/Receiver.java
+++ b/src/de/j4velin/wifiAutoOff/Receiver.java
@@ -93,7 +93,7 @@ public class Receiver extends BroadcastReceiver {
 	}
 	
 	/**
-	 * Changes the WiFi state
+	 * Get default shared preferences
 	 * 
 	 * @param context
 	 *            the context


### PR DESCRIPTION
Most important: If the device was unlocked, the screen off timer was not stopped, if "on_unlock" was not set.
The other changes are more or less cosmetic. See commit messages for more info.
